### PR TITLE
Captura al paso en movimiento inicial de dos casillas

### DIFF
--- a/chess-server/src/main/java/com/uax/chess/controller/Alfil.java
+++ b/chess-server/src/main/java/com/uax/chess/controller/Alfil.java
@@ -18,7 +18,7 @@ public class Alfil extends Ficha {
 
     @Override
     public char obtenerRepresentacion() {
-        return getColor() == TiposColor.BLANCO ? 'A' : 'a';
+        return getColor() == TiposColor.BLANCO ? '♗' : ♝';
     }
 
     @Override

--- a/chess-server/src/main/java/com/uax/chess/controller/Caballo.java
+++ b/chess-server/src/main/java/com/uax/chess/controller/Caballo.java
@@ -19,7 +19,7 @@ public class Caballo extends Ficha {
 
     @Override
     public char obtenerRepresentacion() {
-        return getColor() == TiposColor.BLANCO ? 'C' : 'c';
+        return getColor() == TiposColor.BLANCO ? '♘' : '♞';
     }
 
     @Override

--- a/chess-server/src/main/java/com/uax/chess/controller/Peon.java
+++ b/chess-server/src/main/java/com/uax/chess/controller/Peon.java
@@ -14,6 +14,8 @@ public class Peon extends Ficha {
     public boolean validarMovimiento(int filaOrigen, int columnaOrigen, int filaDestino, int columnaDestino,
             Tablero tablero) {
         int direccion = getColor() == TiposColor.BLANCO ? -1 : 1;
+        capturaPaso = false;
+
 
         // Movimiento estándar
         if (columnaOrigen == columnaDestino && filaDestino - filaOrigen == direccion &&
@@ -23,9 +25,10 @@ public class Peon extends Ficha {
 
         // Movimiento inicial de dos casillas
         if (columnaOrigen == columnaDestino && filaDestino - filaOrigen == 2 * direccion &&
-                (filaOrigen == 6 || filaOrigen == 1) &&
+                filaOrigen == (getColor() == TiposColor.BLANCO ? 6 : 1) &&
                 tablero.getCelda(filaDestino, columnaDestino) == null &&
                 tablero.getCelda(filaOrigen + direccion, columnaDestino) == null) {
+            capturaPaso = true;
             return true;
         }
 

--- a/chess-server/src/main/java/com/uax/chess/controller/Peon.java
+++ b/chess-server/src/main/java/com/uax/chess/controller/Peon.java
@@ -52,7 +52,7 @@ public class Peon extends Ficha {
 
     @Override
     public char obtenerRepresentacion() {
-        return getColor() == TiposColor.BLANCO ? 'P' : 'p';
+        return getColor() == TiposColor.BLANCO ? '♙' : '♟';
     }
 
     @Override

--- a/chess-server/src/main/java/com/uax/chess/controller/Rey.java
+++ b/chess-server/src/main/java/com/uax/chess/controller/Rey.java
@@ -47,7 +47,7 @@ public class Rey extends Ficha {
 
     @Override
     public char obtenerRepresentacion() {
-        return getColor() == TiposColor.BLANCO ? 'K' : 'k';
+        return getColor() == TiposColor.BLANCO ? '♔' : '♚';
     }
 
     @Override

--- a/chess-server/src/main/java/com/uax/chess/controller/Torre.java
+++ b/chess-server/src/main/java/com/uax/chess/controller/Torre.java
@@ -34,7 +34,7 @@ public class Torre extends Ficha {
 
     @Override
     public char obtenerRepresentacion() {
-        return getColor() == TiposColor.BLANCO ? 'T' : 't';
+        return getColor() == TiposColor.BLANCO ? '♖' : '♜';
     }
 
     @Override


### PR DESCRIPTION
He hecho tres correciones He corregido el movimiento inicial para que la fila dependa del color del peón y funcione bien para blancos y negros. También he activado capturaPaso cuando el peón avanza dos casillas y lo reseteo al inicio del método para que no se quede activado de antes. Además, añadí un reset al final si el movimiento no es válido, así la variable siempre queda en su estado correcto.